### PR TITLE
chore: cleanup configuration of the dev/release tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "07:00"
+      time: "21:00"
       timezone: "Asia/Bangkok"
     allow:
       - dependency-type: "production"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "21:00"
+      time: "21:40"
       timezone: "Asia/Bangkok"
     allow:
       - dependency-type: "production"

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,8 @@
-# local notes/scratchpad
-notes/
-
 # GitHubs @dependabot will take care of versioning, using static versions
-package-lock.json
+/package-lock.json
 
-# Created by https://www.toptal.com/developers/gitignore/api/go,sass,hugo,macos,phpstorm,node
-# Edit at https://www.toptal.com/developers/gitignore?templates=go,sass,hugo,macos,phpstorm,node
+# Created by https://www.toptal.com/developers/gitignore/api/go,node,hugo,sass,macos,phpstorm,webstorm,sublimetext
+# Edit at https://www.toptal.com/developers/gitignore?templates=go,node,hugo,sass,macos,phpstorm,webstorm,sublimetext
 
 ### Go ###
 # Binaries for programs and plugins
@@ -47,6 +44,7 @@ hugo.linux
 
 # Icon must end with two \r
 Icon
+
 
 # Thumbnails
 ._*
@@ -287,4 +285,104 @@ fabric.properties
 *.sass.map
 *.scss.map
 
-# End of https://www.toptal.com/developers/gitignore/api/go,sass,hugo,macos,phpstorm,node
+### SublimeText ###
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+### WebStorm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### WebStorm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+
+# End of https://www.toptal.com/developers/gitignore/api/go,node,hugo,sass,macos,phpstorm,webstorm,sublimetext

--- a/.idea/gethugothemes-docs.iml
+++ b/.idea/gethugothemes-docs.iml
@@ -4,5 +4,6 @@
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="hugothemes" />
   </component>
 </module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/gethugothemes-docs.iml" filepath="$PROJECT_DIR$/.idea/gethugothemes-docs.iml" />
+      <module fileurl="file://$PROJECT_DIR$/../hugothemes/.idea/hugothemes.iml" filepath="$PROJECT_DIR$/../hugothemes/.idea/hugothemes.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/.remarkrc
+++ b/.remarkrc
@@ -1,24 +1,5 @@
 {
-  "settings": {
-    "emphasis": "*",
-    "strong": "*"
-  },
   "plugins": [
-    "remark-frontmatter",
-    "remark-preset-lint-recommended",
-    "remark-preset-lint-markdown-style-guide",
-    "lint-fenced-code-flag",
-    ["remark-validate-links", true],
-    ["remark-lint-no-repeat-punctuation", true],
-    ["remark-lint-final-newline", true],
-    ["remark-lint-linebreak-style", "unix"],
-    ["remark-lint-first-heading-level", 2],
-    ["remark-lint-no-html", true],
-    ["remark-lint-list-item-indent", false],
-    ["remark-lint-maximum-line-length", 1000],
-    ["remark-lint-no-file-name-irregular-characters", "\\.a-zA-Z0-9-_"],
-    ["remark-lint-write-good", ["warn", {
-      "whitelist": [ "read-only" ]
-    }]]
+    "remark-preset-lint-dnb"
   ]
 }

--- a/.versionrc.js
+++ b/.versionrc.js
@@ -1,0 +1,2 @@
+const defaultStandardVersion = require('@dnb-hugo/standard-version-config-dnb');
+module.exports = defaultStandardVersion;

--- a/SHORTCODES.md
+++ b/SHORTCODES.md
@@ -34,7 +34,22 @@ tbd.
 
 ### {{< notice >}}
 
-tbd.
+Adds a notice box to the page. The content of the tag will be markdownified.
+
+```markdown
+{{< notice note >}}
+Note with blue background box
+{{< /notice >}}
+{{< notice tip >}}
+Note with green background box
+{{< /notice >}}
+{{< notice info >}}
+Note with yellow background box
+{{< /notice >}}
+{{< notice warning >}}
+Note with red background box
+{{< /notice >}}
+```
 
 ### {{< tab >}}
 

--- a/SHORTCODES.md
+++ b/SHORTCODES.md
@@ -51,11 +51,19 @@ Note with red background box
 {{< /notice >}}
 ```
 
-### {{< tab >}}
+### {{< tabs >}} and {{< tab >}}
 
-tbd.
+Builds a tabbed interface that can be used for configuration code samples.
 
-### {{< tabs >}}
+```markdown
+{{< tabs >}}
+{{< tab "config.yaml" >}}
+`codesample`
+{{< /tab >}}
+{{< tab "config.toml" >}}
+`codesample`
+{{< /tab >}}
+{{< /tabs >}}
+```
 
-tbd.
-
+See `contentblocks/i18n.md` for a sample. The content of the single tabs will be markdownified.

--- a/content/contentblocks/i18n.md
+++ b/content/contentblocks/i18n.md
@@ -9,16 +9,19 @@ This theme is translatable. You can change the sites language in your configurat
 
 After that, open the file in a text editor and translate:
 
-Original (`en.yaml`):
+#### Example:
 
+{{< tabs >}}
+{{< tab "en.yaml" >}}
 ```yaml
 - id: featured_post
   translation: Featured Posts
 ``` 
-
-Translation (`fr.yaml`):
-
+{{< /tab >}}
+{{< tab "fr.yaml" >}}
 ```yaml
 - id: featured_post
   translation: Postes en vedette
 ```
+{{< /tab >}}
+{{< /tabs >}}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gethugothemes-docs",
-  "version": "1.0.0",
-  "description": "Documentation site for Gethugothemes.com",
+  "name": "@gethugothemes/docs",
+  "version": "0.0.0",
+  "description": "Documentation site for gethugothemes.com",
   "homepage": "https://github.com/gethugothemes/gethugothemes-docs#readme",
   "license": "UNLICENSED",
   "repository": {
@@ -12,20 +12,22 @@
     "url": "https://github.com/gethugothemes/gethugothemes-docs/issues"
   },
   "scripts": {
-    "release": "standard-version --release-as patch -a",
-    "release-next": "standard-version --release-as minor -a",
-    "release-major": "standard-version --release-as major -a",
+    "release": "standard-version --release-as patch -a -t \"v\" && git push --follow-tags origin main",
+    "release-next": "standard-version --release-as minor -a -t \"v\" && git push --follow-tags origin main",
+    "release-major": "standard-version --release-as major -a -t \"v\" && git push --follow-tags origin main",
     "serve": "hugo server --disableFastRender --i18n-warnings --navigateToChanged  --templateMetrics --templateMetricsHints --verbose --verboseLog --path-warnings --buildDrafts --buildExpired --buildFuture --watch --enableGitInfo --forceSyncStatic --log true --logFile hugo.log --verbose",
     "hugo": "hugo --i18n-warnings --templateMetrics --templateMetricsHints --verbose --verboseLog --path-warnings --enableGitInfo --log true --logFile hugo.log --verbose",
     "hugo-update": "hugo mod get -u ./... && hugo mod tidy",
     "textlint": "textlint",
     "textlint-fix": "textlint --fix",
-    "lint-md": "remark ."
+    "lint-md": "remark .",
+    "commitlint": "commitlint --from=HEAD~1"
   },
   "keywords": [
     "hugo",
     "hugo-site",
-    "hugo-theme"
+    "hugo-theme",
+    "hugo-documentation"
   ],
   "author": {
     "name": "Mehedi Sharif Titas",
@@ -33,156 +35,48 @@
   },
   "contributors": [
     {
+      "name": "Somrat Sorkar",
+      "web": "https://somrat.netlify.app"
+    },
+    {
       "name": "Patrick Kollitsch",
       "email": "patrick@davids-neighbour.com",
       "web": "https://davids-neighbour.com"
     }
   ],
   "devDependencies": {
-    "@textlint-rule/textlint-rule-no-invalid-control-character": "1.2.0",
-    "@textlint-rule/textlint-rule-no-unmatched-pair": "1.0.7",
-    "commitizen": "4.2.1",
-    "cz-customizable": "6.3.0",
-    "cz-customizable-ghooks": "2.0.0",
-    "remark-cli": "^8.0.1",
-    "remark-frontmatter": "1.3.3",
-    "remark-lint": "^7.0.1",
-    "remark-preset-lint-markdown-style-guide": "^3.0.1",
-    "remark-preset-lint-recommended": "^4.0.1",
-    "remark-validate-links": "^10.0.2",
     "standard-version": "9.0.0",
-    "textlint": "11.7.6",
-    "textlint-plugin-html": "0.2.0",
-    "textlint-rule-abbr-within-parentheses": "1.0.2",
-    "textlint-rule-alex": "3.0.0",
-    "textlint-rule-apostrophe": "2.0.0",
-    "textlint-rule-common-misspellings": "1.0.1",
-    "textlint-rule-date-weekday-mismatch": "1.0.5",
-    "textlint-rule-en-capitalization": "2.0.2",
-    "textlint-rule-en-spell": "1.1.1",
-    "textlint-rule-footnote-order": "1.0.3",
-    "textlint-rule-max-comma": "1.0.4",
-    "textlint-rule-no-dead-link": "4.7.0",
-    "textlint-rule-no-empty-section": "1.1.0",
-    "textlint-rule-no-exclamation-question-mark": "1.1.0",
-    "textlint-rule-no-start-duplicated-conjunction": "2.0.2",
-    "textlint-rule-no-todo": "2.0.1",
-    "textlint-rule-rousseau": "1.4.6",
-    "textlint-rule-spelling": "0.2.0",
-    "textlint-rule-stop-words": "2.0.7",
-    "textlint-rule-terminology": "2.1.4",
-    "textlint-rule-unexpanded-acronym": "1.2.4"
+    "@commitlint/cli": "11.0.0",
+    "husky": "4.3.0",
+    "@dnb-hugo/browserslist-config-dnb": "github:dnb-hugo/browserslist-config-dnb",
+    "@dnb-hugo/commitlint-config-dnb": "github:dnb-hugo/commitlint-config-dnb",
+    "@dnb-hugo/remark-preset-lint-dnb": "github:dnb-hugo/remark-preset-lint-dnb",
+    "@dnb-hugo/standard-version-config-dnb": "github:dnb-hugo/standard-version-config-dnb",
+    "@dnb-hugo/stylelint-config-dnb": "github:dnb-hugo/stylelint-config-dnb"
   },
   "config": {
     "commitizen": {
       "path": "node_modules/cz-customizable"
     },
     "cz-customizable": {
-      "config": ".cz_config.js"
+      "config": ".cz-config.js"
     }
   },
-  "standard-version": {
-    "skip": {
-      "changelog": true
-    },
-    "bumpFiles": [
-      {
-        "filename": "package.json",
-        "type": "json"
-      }
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  },
+  "browserslist": [
+    "extends browserslist-config-dnb"
+  ],
+  "commitlint": {
+    "extends": [
+      "@dnb-hugo/commitlint-config-dnb"
     ]
   },
-  "textlint": {
-    "rules": {
-      "no-todo": true,
-      "textlint-rule-no-start-duplicated-conjunction": true,
-      "max-comma": {
-        "max": 3
-      },
-      "no-exclamation-question-mark": true,
-      "no-dead-link": {
-        "checkRelative": true,
-        "baseURI": null,
-        "ignore": [],
-        "preferGET": [],
-        "ignoreRedirects": false,
-        "retry": 3,
-        "userAgent": "textlint-rule-no-dead-link/1.0"
-      },
-      "en-spell": true,
-      "en-capitalization": {
-        "allowHeading": true,
-        "allowFigures": true,
-        "allowLists": true,
-        "allowWords": []
-      },
-      "stop-words": {
-        "defaultWords": true,
-        "skip": [
-          "Blockquote"
-        ],
-        "exclude": [
-          "utilize",
-          "period of time"
-        ]
-      },
-      "apostrophe": true,
-      "common-misspellings": {
-        "ignore": []
-      },
-      "date-weekday-mismatch": true,
-      "terminology": {
-        "defaultTerms": true,
-        "skip": [
-          "Blockquote"
-        ],
-        "exclude": [
-          "CSS"
-        ]
-      },
-      "alex": {
-        "allow": [
-          "boogeyman-boogeywoman"
-        ]
-      },
-      "rousseau": {
-        "showLevels": [
-          "suggestion",
-          "warning",
-          "error"
-        ]
-      },
-      "abbr-within-parentheses": true,
-      "spelling": {
-        "language": "en",
-        "skipPatterns": [
-          "JavaScript"
-        ],
-        "wordDefinitionRegexp": "/[\\w']+/g",
-        "suggestCorrections": true
-      },
-      "unexpanded-acronym": {
-        "min_acronym_len": 3
-      },
-      "footnote-order": true,
-      "@textlint-rule/no-unmatched-pair": true,
-      "@textlint-rule/no-invalid-control-character": true,
-      "no-empty-section": true,
-      "no-start-duplicated-conjunction": {
-        "interval": 2
-      }
-    },
-    "plugins": [
-      "html"
-    ]
+  "stylelint": {
+    "extends": "stylelint-config-dnb/scss"
   },
-  "dependencies": {
-    "remark-lint-fenced-code-flag": "^2.0.1",
-    "remark-lint-final-newline": "^1.0.5",
-    "remark-lint-first-heading-level": "^2.0.1",
-    "remark-lint-linebreak-style": "^2.0.1",
-    "remark-lint-no-html": "^2.0.1",
-    "remark-lint-no-repeat-punctuation": "^0.1.3",
-    "remark-lint-write-good": "^1.2.0"
-  }
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "name": "Mehedi Sharif Titas",
     "web": "https://gethugothemes.com"
   },
-  "contributors": [
+  "maintainers": [
     {
       "name": "Somrat Sorkar",
       "web": "https://somrat.netlify.app"

--- a/themes/godocs-hugo/layouts/shortcodes/notice.html
+++ b/themes/godocs-hugo/layouts/shortcodes/notice.html
@@ -1,3 +1,3 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
-
-<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}><p>{{ .Inner | markdownify }}</p></div>
+<div class="notices {{ .Get 0 }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
+    <p>{{ .Inner | markdownify }}</p>
+</div>

--- a/themes/godocs-hugo/layouts/shortcodes/tab.html
+++ b/themes/godocs-hugo/layouts/shortcodes/tab.html
@@ -1,5 +1,3 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
-
 <div class="tab-pane" title="{{ .Get 0 }}">
-  {{ .Inner }}
+  {{ .Inner | markdownify }}
 </div>

--- a/themes/godocs-hugo/layouts/shortcodes/tabs.html
+++ b/themes/godocs-hugo/layouts/shortcodes/tabs.html
@@ -1,5 +1,3 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
-
 <div class="code-tabs">
   <ul class="nav nav-tabs"></ul>
   <div class="tab-content">{{ .Inner }}</div>


### PR DESCRIPTION
This PR cleans up the package.json and other configuration files:

- set @dependabot to check at 9 pm (to test it's run)
- remove all textlint and remark setup
- re-add distributed remark configuration
- add distributed configurations for commit-lint, commitizen, standard-version and stylelint
- add proper maintainers
- update .gitignore file with webstorm and sublime lint
- adding docs for tabs and tab shortcodes (this one wiggled it's way into the PR, sorry)

The reason for this change is, that textlint and remark packages might change often and this will create additional work for us to upgrade these changes. This is done globally in the config packages and this repo can be updated once with all updated packages.