### PR TITLE
fix: sidebar navigation does not activate current section

### DIFF
--- a/SHORTCODES.md
+++ b/SHORTCODES.md
@@ -2,6 +2,20 @@
 
 The following shortcodes are available to use on this website:
 
+### {{< box >}}
+
+This shortcode creates a visually highlighted box.
+
+```markdown
+{{< box title="Title" link="link" class="md5" >}}
+```
+
+- `title` (required) 
+- `link` (optional) links the title to an URI
+- `class` (optional) add classes. if not set an `mb-3` is set. Adding this parameter will override the default setting.
+
+The content of the shortcode will be markdownified.
+
 ### {{< changelog >}}
 
 tbd.

--- a/content/faq.md
+++ b/content/faq.md
@@ -1,7 +1,7 @@
 ---
 title: "Mostly Asked Questions"
 description: "this is meta description"
-draft: false
+draft: true
 ---
 
 {{< faq "Will updates also be free?" >}}

--- a/content/faq.md
+++ b/content/faq.md
@@ -1,7 +1,7 @@
 ---
 title: "Mostly Asked Questions"
 description: "this is meta description"
-draft: true
+draft: false
 ---
 
 {{< faq "Will updates also be free?" >}}

--- a/content/godocs-hugo/installation.md
+++ b/content/godocs-hugo/installation.md
@@ -37,7 +37,7 @@ If everything went well then you can now load your website at [localhost:1313](h
 
 - Check out, how to [configure the features]({{< ref "configuration" >}}) of this theme.
 - Read about [how to publish your new website]({{< ref "cms-integration" >}}) with Netlify and Forestry.io.
-- Learn how to [structure your content]({{< ref "content-structure" >}}) and [translate your website]({{< ref "i18n" >}}) to your site.
+- Learn how to [structure your content]({{< ref "content-structure" >}}) and [translate your website]({{< ref "i18n" >}}).
 
 ## Video documentation
 

--- a/content/guide.md
+++ b/content/guide.md
@@ -5,7 +5,7 @@ layout: guide
 draft: false
 ---
 
-Welcome! This guide will help you get started with a Hugo Theme, including how to run, customize, and update your theme!
+Welcome! This guide will help you to get started with a Hugo Theme, including how to run, customize, and update your theme!
 
 ---
 
@@ -13,22 +13,15 @@ Welcome! This guide will help you get started with a Hugo Theme, including how t
 
 There are two main ways to setup your hugo theme.
 
-<div class="box">
-  <a href="#local-development" class="box-title">Local Development</a><br>
-  Step-by-step instructions on how to install Hugo and start a project: written for people without Hugo development experience, though these learning resources have helped developers of all skill levels.
-</div>
-<br>
-<div class="box">
-  <a href="#github--netlify--forestry" class="box-title">Quick Start</a><br>
-  One page summary of how to setup your theme without writing a line of code.
-</div>
-<br>
-<br>
+{{< box title="Local Development" link="#local-development" >}}
+Step-by-step instructions on how to install Hugo and start a project: written for people without Hugo development experience, though these learning resources have helped developers of all skill levels.
+{{< /box >}}
+
+{{< box title="Quick Start" link="#github--netlify--forestry" class="mb-5">}}
+One page summary of how to setup your theme without writing a line of code.
+{{< /box >}}
 
 ---
-
-<br>
-<br>
 
 ## Local Development
 

--- a/content/timeframe-hugo/installation.md
+++ b/content/timeframe-hugo/installation.md
@@ -37,7 +37,7 @@ If everything went well then you can now load your website at [localhost:1313](h
 
 - Check out, how to [configure the features]({{< ref "configuration" >}}) of this theme.
 - Read about [how to publish your new website]({{< ref "cms-integration" >}}) with Netlify and Forestry.io.
-- Learn how to [create blog posts]({{< ref "blog-post" >}}) and [add speaker pages]({{< ref "speakers" >}}) to your site.
+- Learn how to [translate your website]({{< ref "i18n" >}}).
 
 ## Video documentation
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+
   "name": "@gethugothemes/docs",
   "version": "0.0.0",
   "description": "Documentation site for gethugothemes.com",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-
   "name": "@gethugothemes/docs",
   "version": "0.0.0",
   "description": "Documentation site for gethugothemes.com",

--- a/themes/godocs-hugo/layouts/shortcodes/box.html
+++ b/themes/godocs-hugo/layouts/shortcodes/box.html
@@ -1,0 +1,11 @@
+{{- $title := .Get "title" -}}
+{{- $link := .Get "link" -}}
+{{- $class := .Get "class" -}}
+<div class="box{{ with $class }} {{ $class }}{{ else }} mb-3{{ end }}">
+    <div class="h5">
+        {{- with $link -}}<a href="{{ . }}">{{- end -}}
+        {{- $title -}}
+        {{- with $link -}}</a>{{- end -}}
+    </div>
+    {{- .Inner | markdownify -}}
+</div>


### PR DESCRIPTION
Scrolling through for instance [the guide](https://docs.gethugothemes.com/guide) marks the first item in the navigation active, then deactivates it but does not activate the next item. This has to do with `box-title` as class on the two big boxes in the beginning of the page. [It appears that they are somehow used in the javascript](https://github.com/gethugothemes/gethugothemes-documentation-site/blob/d3fb401d022ed94f88cd7bd71fc3a689d9d28789/themes/godocs-hugo/assets/js/script.js#L172) and interfere. 

- [x] added shortcode for box
- [x] added shortcode doc for box
- [x] refactored guide to use shortcode 
- [ ] set FAQ to draft (as long as we have no content)